### PR TITLE
Reorder javascript dependencies so fingerprint and store load before dallinger2.js

### DIFF
--- a/templates/consent.html
+++ b/templates/consent.html
@@ -12,6 +12,8 @@
         <link rel="stylesheet" href="/static/css/bootstrap.min.css" type="text/css">
         <link rel="stylesheet" href="/static/css/dallinger.css" type="text/css">
         <script src="/static/scripts/reqwest.min.js" type="text/javascript"> </script>
+        <script src="https://cdnjs.cloudflare.com/ajax/libs/fingerprintjs2/1.5.1/fingerprint2.min.js" type="text/javascript"></script>
+        <script src="/static/scripts/store+json2.min.js" type="text/javascript"> </script>
         <script src="/static/scripts/dallinger2.js" type="text/javascript"> </script>
     </head>
     <body>

--- a/templates/exp.html
+++ b/templates/exp.html
@@ -3,6 +3,8 @@
 <head>
   <script src="/static/scripts/jquery-min.js" type="text/javascript"> </script>
   <script src="/static/scripts/reqwest.min.js" type="text/javascript"> </script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/fingerprintjs2/1.5.1/fingerprint2.min.js" type="text/javascript"></script>
+  <script src="/static/scripts/store+json2.min.js" type="text/javascript"> </script>
   <script src="/static/scripts/dallinger2.js" type="text/javascript"> </script>
   <script src="/static/scripts/reconnecting-websocket.js"></script>
   <link rel="stylesheet" type="text/css" href="static/css/bootstrap.min.css">
@@ -13,7 +15,6 @@
   <script src="/static/scripts/mousetrapExtension-pause.min.js" type="text/javascript"> </script>
   <script src="/static/scripts/helpers.js" type="text/javascript"> </script>
   <script src="/static/scripts/experiment.js" type="text/javascript"> </script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/fingerprintjs2/1.5.1/fingerprint2.min.js" type="text/javascript"></script>
   <link rel=stylesheet href="/static/css/bootstrap.min.css" type="text/css">
 </head>
 <body>

--- a/templates/instructions/instruct-1.html
+++ b/templates/instructions/instruct-1.html
@@ -3,8 +3,9 @@
     <link rel="stylesheet" href="/static/css/dallinger.css" type="text/css">
     <script src="https://code.jquery.com/jquery-2.2.4.min.js" integrity="sha256-BbhdlvQf/xTY9gja0Dq3HiwQF8LaCRTXxZKRutelT44=" crossorigin="anonymous"></script>
     <script src="/static/scripts/reqwest.min.js" type="text/javascript"> </script>
-    <script src="/static/scripts/dallinger2.js" type="text/javascript"> </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fingerprintjs2/1.5.1/fingerprint2.min.js" type="text/javascript"></script>
+    <script src="/static/scripts/store+json2.min.js" type="text/javascript"> </script>
+    <script src="/static/scripts/dallinger2.js" type="text/javascript"> </script>
 </head>
 
 <body>

--- a/templates/instructions/instruct-2.html
+++ b/templates/instructions/instruct-2.html
@@ -2,8 +2,9 @@
     <link rel="stylesheet" href="/static/css/bootstrap.min.css" type="text/css">
     <link rel="stylesheet" href="/static/css/dallinger.css" type="text/css">
     <script src="/static/scripts/reqwest.min.js" type="text/javascript"> </script>
-    <script src="/static/scripts/dallinger2.js" type="text/javascript"> </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fingerprintjs2/1.5.1/fingerprint2.min.js" type="text/javascript"></script>
+    <script src="/static/scripts/store+json2.min.js" type="text/javascript"> </script>
+    <script src="/static/scripts/dallinger2.js" type="text/javascript"> </script>
 </head>
 
 <body>

--- a/templates/instructions/instruct-3.html
+++ b/templates/instructions/instruct-3.html
@@ -2,8 +2,9 @@
     <link rel="stylesheet" href="/static/css/bootstrap.min.css" type="text/css">
     <link rel="stylesheet" href="/static/css/dallinger.css" type="text/css">
     <script src="/static/scripts/reqwest.min.js" type="text/javascript"> </script>
-    <script src="/static/scripts/dallinger2.js" type="text/javascript"> </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fingerprintjs2/1.5.1/fingerprint2.min.js" type="text/javascript"></script>
+    <script src="/static/scripts/store+json2.min.js" type="text/javascript"> </script>
+    <script src="/static/scripts/dallinger2.js" type="text/javascript"> </script>
 </head>
 
 <body>

--- a/templates/instructions/instruct-4.html
+++ b/templates/instructions/instruct-4.html
@@ -2,8 +2,9 @@
     <link rel="stylesheet" href="/static/css/bootstrap.min.css" type="text/css">
     <link rel="stylesheet" href="/static/css/dallinger.css" type="text/css">
     <script src="/static/scripts/reqwest.min.js" type="text/javascript"> </script>
-    <script src="/static/scripts/dallinger2.js" type="text/javascript"> </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fingerprintjs2/1.5.1/fingerprint2.min.js" type="text/javascript"></script>
+    <script src="/static/scripts/store+json2.min.js" type="text/javascript"> </script>
+    <script src="/static/scripts/dallinger2.js" type="text/javascript"> </script>
 </head>
 <body>
     <div class="main_div">

--- a/templates/instructions/instruct-ready.html
+++ b/templates/instructions/instruct-ready.html
@@ -2,8 +2,9 @@
     <link rel="stylesheet" href="/static/css/bootstrap.min.css" type="text/css">
     <link rel="stylesheet" href="/static/css/dallinger.css" type="text/css">
     <script src="/static/scripts/reqwest.min.js" type="text/javascript"> </script>
-    <script src="/static/scripts/dallinger2.js" type="text/javascript"> </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/fingerprintjs2/1.5.1/fingerprint2.min.js" type="text/javascript"></script>
+    <script src="/static/scripts/store+json2.min.js" type="text/javascript"> </script>
+    <script src="/static/scripts/dallinger2.js" type="text/javascript"> </script>
 </head>
 <body>
     <div class="main_div">

--- a/templates/questionnaire.html
+++ b/templates/questionnaire.html
@@ -1,6 +1,8 @@
 <head>
     <script src="/static/scripts/jquery-min.js" type="text/javascript"> </script>
     <script src="/static/scripts/reqwest.min.js" type="text/javascript"> </script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/fingerprintjs2/1.5.1/fingerprint2.min.js" type="text/javascript"></script>
+    <script src="/static/scripts/store+json2.min.js" type="text/javascript"> </script>
     <script src="/static/scripts/dallinger2.js" type="text/javascript"> </script>
     <script src="/static/scripts/reconnecting-websocket.js"></script>
     <link rel="stylesheet" type="text/css" href="static/css/bootstrap.min.css">
@@ -12,7 +14,6 @@
     <script src="/static/scripts/helpers.js" type="text/javascript"> </script>
     <script src="/static/scripts/questionnaire.js" type="text/javascript"> </script>
     <script src="/static/scripts/spin.min.js" type="text/javascript"> </script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/fingerprintjs2/1.5.1/fingerprint2.min.js" type="text/javascript"></script>
 </head>
 <body>
     <h1>Finished.</h1>


### PR DESCRIPTION
This fixes the ordering of script tags to stop javascript errors blocking progression